### PR TITLE
update website for beta 2

### DIFF
--- a/app/views/pages/_section_banner.html.erb
+++ b/app/views/pages/_section_banner.html.erb
@@ -13,7 +13,7 @@
       <p class="mt-4 mb-5">Available for <a href="#downloads" onclick="ga('send', 'event', 'Button', 'Download', 'Linux link Banner')">Linux</a>, <a href="#downloads" onclick="ga('send', 'event', 'Button', 'Download', 'Windows link Banner')">Windows</a> and <a href="#downloads" onclick="ga('send', 'event', 'Button', 'Download', 'MacOs link Banner')">MacOs</a></p>
     </div>
     <div class="col-md-4" data-aos="zoom-in-up" data-aos-duration="7000">
-      <%= link_to "Online PGP tool", online_pgp_tool_path, target: "_blank", onclick: "ga('send', 'event', 'Button', 'Online pgp tool', 'Button Banner')",class: "btn btn-outline-primary btn-lg rounded p-3" %>
+      <%= link_to "Online PGP tool", online_pgp_tool_path, target: "_blank", onclick: "ga('send', 'event', 'Button', 'Online pgp tool', 'Button Banner')", class: "btn btn-outline-primary btn-lg rounded p-3" %>
       <p class="mt-4">Get started for free!</p>
     </div>
   </div>

--- a/app/views/pages/_section_downloads.html.erb
+++ b/app/views/pages/_section_downloads.html.erb
@@ -5,14 +5,14 @@
       <h3 class="mb-4">Windows</h3>
       <i class="fab fa-windows fa-5x"></i>
       <div class="mt-3">
-        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.1/aliceandbob.io-1.0.0-Beta.1_x64.Setup.exe"
+        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.2/aliceandbob.io-1.0.0-Beta.2_x64.Setup.exe"
         class="btn btn-info"
         onclick="ga('send', 'event', 'Button', 'Download', 'Windows x64 Download Section')">
           <i class="fab fa-windows"></i> Windows x64
         </a>
       </div>
       <div class="mt-3">
-        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.1/aliceandbob.io-1.0.0-Beta.1_x32.Setup.exe"
+        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.2/aliceandbob.io-1.0.0-Beta.2_x32.Setup.exe"
         class="btn btn-info"
         onclick="ga('send', 'event', 'Button', 'Download', 'Windows x32 Download Section')">
           <i class="fab fa-windows"></i> Windows x32
@@ -23,14 +23,14 @@
       <h3 class="mb-4">Linux</h3>
       <i class="fab fa-linux fa-5x"></i>
       <div class="mt-3">
-        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.1/aliceandbob.io_1.0.0-Beta.1_amd64.deb"
+        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.2/aliceandbob.io_1.0.0-Beta.2_amd64.deb"
         class="btn btn-info"
         onclick="ga('send', 'event', 'Button', 'Download', 'Linux .deb Download Section')">
           <i class="fab fa-ubuntu"></i> Linux (.deb)
         </a>
       </div>
       <div class="mt-3">
-        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.1/aliceandbob.io-1.0.0.Beta.1-1.x86_64.rpm"
+        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.2/aliceandbob.io-1.0.0.Beta.2-1.x86_64.rpm"
         class="btn btn-info"
         onclick="ga('send', 'event', 'Button', 'Download', 'Linux .rpm Download Section')">
           <i class="fab fa-redhat"></i> Linux (.rpm)
@@ -41,7 +41,7 @@
       <h3 class="mb-4">MacOs</h3>
       <i class="fab fa-apple fa-5x"></i>
       <div class="mt-3">
-        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.1/aliceandbob.io-darwin-x64-1.0.0-Beta.1.zip"
+        <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases/download/1.0.0-beta.2/aliceandbob.io-darwin-x64-1.0.0-Beta.2.zip"
         class="btn btn-info"
         onclick="ga('send', 'event', 'Button', 'Download', 'MacOs .zip Download Section')">
           <i class="fas fa-file-archive"></i> MacOs (.zip)
@@ -49,5 +49,5 @@
       </div>
     </div>
   </div>
-  <p>You can also visit the <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases" target="_blank">Github page</a> where more download options might be available.</p>
+  <p>You can also visit the <a href="https://github.com/aliceandbob-io/aliceandbob-desktop/releases" target="_blank" onclick="ga('send', 'event', 'Button', 'Download', 'Github Downloads Option')">Github page</a> where more download options might be available.</p>
 </section>

--- a/app/views/pages/_section_features.html.erb
+++ b/app/views/pages/_section_features.html.erb
@@ -7,12 +7,11 @@
     <div class="col-md-6 col-lg-5 text-left p-3 order-1 order-md-2">
       <h3 class="mb-5"><span class="badge badge-pill badge-primary">1</span> Creation</h3>
       <p>Generate PGP key pairs using your email and a passphrase.</p>
+      <p>You also can choose from different encryption options.</p>
       <p><strong>Comming Soon:</strong></p>
-        <p>
-          - Choose the type of encryption for key pair;<br />
-          - Export your keys in the <mark class="text-monospace">.pgp</mark> format;<br />
-          - Upload your own public keys to <a href="https://en.wikipedia.org/wiki/Key_server_(cryptographic)" target="_blank">HKP servers</a>.
-        </p>
+      <p>
+        - Export your keys in different file formats;<br />
+        - Upload your own public keys to <a href="https://en.wikipedia.org/wiki/Key_server_(cryptographic)" target="_blank">HKP servers</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Update features and download options to match the v1.0.0.Beta.2 of the desktop application.
See [releases here](https://github.com/aliceandbob-io/aliceandbob-desktop/releases/tag/1.0.0-beta.2 ).