### PR TITLE
feat: warn users about the new to come v5 of openpgp.js

### DIFF
--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -251,6 +251,6 @@ select option {
   display: inline-block;
 }
 
-.error {
+.error, .warning {
   font-weight: 300;
 }

--- a/app/views/online_pgp_tool/_decrypt.html.erb
+++ b/app/views/online_pgp_tool/_decrypt.html.erb
@@ -3,6 +3,9 @@
   <div class="row d-none error bg-danger rounded p-3 mb-4" data-target="decrypt.error">
     <span>An error has occured. Please verify the submitted data or try again later.</span>
   </div>
+  <div class="row warning bg-warning rounded p-3 mb-4">
+    <span>This tool will soon migrate to a new version of openPGP.js: <kbd>brainpool</kbd> and <kbd>secp256k1</kbd> options will not be supported anymore for generating, encryption and decryption.</span>
+  </div>
   <div class="row mb-3">
     <div class="col-lg-6">
         <label>Text to decrypt</label>

--- a/app/views/online_pgp_tool/_encrypt.html.erb
+++ b/app/views/online_pgp_tool/_encrypt.html.erb
@@ -3,6 +3,9 @@
   <div class="row d-none error bg-danger rounded p-3 mb-4" data-target="encrypt.error">
     <span>An error has occured. Please verify the submitted data or try again later.</span>
   </div>
+  <div class="row warning bg-warning rounded p-3 mb-4">
+    <span>This tool will soon migrate to a new version of openPGP.js: <kbd>brainpool</kbd> and <kbd>secp256k1</kbd> options will not be supported anymore for generating, encryption and decryption.</span>
+  </div>
   <div class="row mb-3">
     <div class="col-lg-6">
       <label>Text to encrypt</label>

--- a/app/views/online_pgp_tool/_generate.html.erb
+++ b/app/views/online_pgp_tool/_generate.html.erb
@@ -3,6 +3,9 @@
   <div class="row d-none error bg-danger rounded p-3 mb-4" data-target="keys.error">
     <span>An error has occured. Please verify the submitted data or try again later.</span>
   </div>
+  <div class="row warning bg-warning rounded p-3 mb-4">
+    <span>This tool will soon migrate to a new version of openPGP.js: <kbd>brainpool</kbd> and <kbd>secp256k1</kbd> options will not be supported anymore for generating, encryption and decryption.</span>
+  </div>
   <div class="row mb-3">
     <div class="col">
       <div class="form-group mb-3">


### PR DESCRIPTION
**aliceandbob will soon migrate to the v.5 of openPGP.js.**

This feature warns users about this change: brainpool and secp256k1 options will not be supported anymore to generate key pairs,  encrypt and decrypt messages.
It is only shown on the online PGP tool, not on the landing page.